### PR TITLE
Allow override removal of legacy time clients, update for focal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ With these tags, only specific parts of the role can be triggered:
   service; the purpose of the plain `service` tag is that you can enable and
   start all services across roles by using this tag, e.g. `ansible-playbook
   site.yml -t service`
+- `remove-legacy-clients`: tag associated with removal of legacy chrony,ntp client packages;
+  the purpose of this tag is to allow for package removals to be optionally excluded.
 
 The tags from the [Example Playbook](#example-playbook) are `timesyncd` and
 `timesync`. In case you switch from different time synchronization roles, the

--- a/README.md
+++ b/README.md
@@ -128,7 +128,16 @@ dependencies:
 
 ...
 ```
+Role Variables
+--------------
 
+### Base Variables
+
+```yml
+purge_legacy_packages: True
+
+```
+Override this variable to omit the task of removing any legacy time clients (ntp, chrony)
 
 Tags
 ----
@@ -142,8 +151,6 @@ With these tags, only specific parts of the role can be triggered:
   service; the purpose of the plain `service` tag is that you can enable and
   start all services across roles by using this tag, e.g. `ansible-playbook
   site.yml -t service`
-- `remove-legacy-clients`: tag associated with removal of legacy chrony,ntp client packages;
-  the purpose of this tag is to allow for package removals to be optionally excluded.
 
 The tags from the [Example Playbook](#example-playbook) are `timesyncd` and
 `timesync`. In case you switch from different time synchronization roles, the

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ ntp_fallback_servers:
   - 2.europe.pool.ntp.org
   - 3.europe.pool.ntp.org
 ```
+### Purge legacy time clients
+
+```yml
+purge_legacy_packages: True
+
+```
+Override this default variable to omit the task of removing any legacy time clients (ntp, chrony)
 
 
 Dependencies
@@ -128,16 +135,6 @@ dependencies:
 
 ...
 ```
-Role Variables
---------------
-
-### Base Variables
-
-```yml
-purge_legacy_packages: True
-
-```
-Override this variable to omit the task of removing any legacy time clients (ntp, chrony)
 
 Tags
 ----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+purge_legacy_packages: True

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
 
   galaxy_tags:
     - ntp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,8 @@
   package:
     name: chrony,ntp
     state: absent
+  tags:
+    - remove-legacy-clients
 
 - name: install systemd
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,7 @@
   package:
     name: chrony,ntp
     state: absent
-  tags:
-    - remove-legacy-clients
+  when: purge_legacy_packages
 
 - name: install systemd
   package:


### PR DESCRIPTION
Hi Christian,
As discussed, I've added OS support for Ubuntu focal, and created a default variable to be overridden in cases where a user would not want to remove legacy time clients.

Thanks,
 - Kodiak