### PR TITLE
Fix masked state on systemd-timesyncd

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,11 @@
   ansible.builtin.package:
     name: systemd
 
+- name: install systemd-timesyncd
+  ansible.builtin.package:
+    name: systemd-timesyncd
+    state: present
+
 - name: configure systemd-timesyncd
   ansible.builtin.template:
     src: timesyncd.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     - timesyncd-service
 
 - name: Install systemd-timesyncd
-  ansible.builtin.package:
+  ansible.builtin.service:
     name: systemd-timesyncd
     state: present
   when: (ansible_facts.services["systemd-timesyncd.service"].status == "not-found") or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     - timesyncd-service
 
 - name: Install systemd-timesyncd
-  ansible.builtin.service:
+  ansible.builtin.package:
     name: systemd-timesyncd
     state: present
   when: (ansible_facts.services["systemd-timesyncd.service"].status == "not-found") or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,10 +25,19 @@
     mode: 0644
   register: __systemd_timesyncd_configuration
 
-- name: install systemd-timesyncd
+- name: Get service facts
+  ansible.builtin.service_facts:
+  tags:
+    - service
+    - service-timesyncd
+    - timesyncd-service
+
+- name: Install systemd-timesyncd
   ansible.builtin.package:
     name: systemd-timesyncd
     state: present
+  when: (ansible_facts.services["systemd-timesyncd.service"].status == "not-found") or
+        (ansible_facts.services["systemd-timesyncd.service"].status == "masked")
   tags:
     - service
     - service-timesyncd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,11 +16,6 @@
   ansible.builtin.package:
     name: systemd
 
-- name: install systemd-timesyncd
-  ansible.builtin.package:
-    name: systemd-timesyncd
-    state: present
-
 - name: configure systemd-timesyncd
   ansible.builtin.template:
     src: timesyncd.conf.j2
@@ -29,6 +24,15 @@
     group: root
     mode: 0644
   register: __systemd_timesyncd_configuration
+
+- name: install systemd-timesyncd
+  ansible.builtin.package:
+    name: systemd-timesyncd
+    state: present
+  tags:
+    - service
+    - service-timesyncd
+    - timesyncd-service
 
 - name: enable systemd-timesyncd service and assure it is started
   ansible.builtin.service:


### PR DESCRIPTION
Reinstall systemd-timesyncd service

Checked on Ubuntu 22.04 with installed `ntp` package and masked `systemd-timesyncd`

Resolves: #3
