### PR TITLE
add support for debian

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - wip/next
+      - debian
 
 jobs:
 
@@ -28,6 +29,8 @@ jobs:
           - archlinux
           - ubuntu-focal
           - ubuntu-jammy
+          - debian-bullseye
+          - debian-bookworm
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
       - wip/next
-      - debian
 
 jobs:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,6 +23,11 @@ galaxy_info:
         - focal
         - jammy
 
+    - name: Debian
+      versions:
+        - bookworm
+        - bullseye
+
   galaxy_tags:
     - ntp
     - systemd

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -32,6 +32,24 @@ platforms:
     privileged: yes
     pre_build_image: yes
 
+  - name: debian-bullseye
+    image: geerlingguy/docker-debian11-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: yes
+    pre_build_image: yes
+
+  - name: debian-bookworm
+    image: geerlingguy/docker-debian12-ansible
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: yes
+    pre_build_image: yes
+
 provisioner:
   name: ansible
   inventory:

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,5 @@
+---
+
+__systemd_timesyncd_package: systemd-timesyncd
+
+...


### PR DESCRIPTION
Adding file `vars/debian.yml` to define *systemd-timesyncd* package name.

Without this change, is the role using just *systemd* as is described in `vars/default.yml` and the role is not able to install right package on Debian system. 